### PR TITLE
Add the Sysbox runtime to the Containers list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Hypervisor-based (KVM, Xen, QEMU) Runtime for OCI. Security by isolation.
 Full management of container lifecycle.
 * [firecracker](https://github.com/firecracker-microvm/firecracker)  
 Firecracker runs workloads in lightweight virtual machines, called microVMs, which combine the security and isolation properties provided by hardware virtualization technology with the speed and flexibility of containers.
+* [sysbox](https://github.com/nestybox/sysbox)
+Sysbox is a "runc" that creates secure (rootless) containers / pods that run not just microservices, but most workloads that run in VMs (e.g., systemd, Docker, and Kubernetes), seamlessly.
 
 ## Sandboxes
 


### PR DESCRIPTION
The Sysbox runtime is a next-generation container runtime ("runc") designed to enable secure (rootless) containers to run most workloads that run in VMs, natively (no complex images, tricky entrypoints, special mounts, etc.). The Sysbox project has close to 800 GH stars already, and used by several enterprises.

Thanks for this awesome list!