### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Basic docker monitoring web application.
 Lightweight Docker management UI.
 * [swarmpit](https://github.com/swarmpit/swarmpit)  
 Lightweight mobile-friendly Docker Swarm management UI.
+* [KubeStellar Console](https://github.com/kubestellar/console)  
+Multi-cluster Kubernetes dashboard with real-time observability across containerized workloads.
 
 ## Best practices
 


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*